### PR TITLE
Use coupling as x_value_option 

### DIFF
--- a/mdsine2/posterior.py
+++ b/mdsine2/posterior.py
@@ -2399,7 +2399,7 @@ class TrajectorySet(pl.graph.Node):
         '''
         for ridx in range(self.G.data.n_replicates):
             for tidx in range(self.G.data.n_timepoints_for_replicate[ridx]):
-                for oidx in range(self.G.data.taxas.n_taxas):
+                for oidx in range(self.G.data.n_taxa):
                     yield (ridx, tidx, oidx)
 
     def set_trace(self, *args, **kwargs):

--- a/mdsine2/posterior.py
+++ b/mdsine2/posterior.py
@@ -2394,6 +2394,14 @@ class TrajectorySet(pl.graph.Node):
             vals = np.append(vals, data.value)
         return vals
 
+    def iter_indices(self) -> Tuple[int, int, int]:
+        '''Iterate through the indices and the values
+        '''
+        for ridx in range(self.G.data.n_replicates):
+            for tidx in range(self.G.data.n_timepoints_for_replicate[ridx]):
+                for oidx in range(self.G.data.taxas.n_taxas):
+                    yield (ridx, tidx, oidx)
+
     def set_trace(self, *args, **kwargs):
         for ridx in range(len(self.value)):
             self.value[ridx].set_trace(*args, **kwargs)


### PR DESCRIPTION
I wanted to try `coupling` as `x_value_option`, but it didn't work because `iter_indices` method was deleted from `TrajectorySet`.
Therefore, I recovered it.