### PR TITLE
Fix: Update dependencies for Python and scikit-learn (#28, #29)

### DIFF
--- a/conda_recipe.yml
+++ b/conda_recipe.yml
@@ -1,18 +1,18 @@
-name: mdsine2
+name: mdsine21
 
 channels:
   - conda-forge
   - bioconda
 
 dependencies:
-  - python
+  - python=3.10
   - numpy
   - numba
   - pandas
   - scipy
   - matplotlib
   - seaborn
-  - scikit-learn
+  - scikit-learn=1.1.3
   - h5py
   - psutil
   - networkx


### PR DESCRIPTION
These are the short term fixes for Issues #28 and #29 

#28: The current `ete3` package uses `import cgi`, which was deprecated in Python 3.11 and removed in Python 3.13.
#29: The calls to scikit-learn AgglomerativeClustering use a syntax that is no longer valid.